### PR TITLE
Fix case when registry does not exist

### DIFF
--- a/src/zeal_cli/zeal/config.py
+++ b/src/zeal_cli/zeal/config.py
@@ -19,9 +19,12 @@ class Config:
         if platform.system() == "Linux":
             return Path("~", ".local", "share", "Zeal", "Zeal", "docsets").expanduser()
         elif platform.system() == "Windows":
-            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Zeal\\Zeal\\docsets") as key:
-                path, _type = winreg.QueryValueEx(key, "path")
-                return Path(path).expanduser()
+            try:
+                with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Zeal\\Zeal\\docsets") as key:
+                    path, _type = winreg.QueryValueEx(key, "path")
+                    return Path(path).expanduser()
+            except FileNotFoundError:
+                return Path("~/", "AppData", "Local", "Zeal", "Zeal", "docsets").expanduser()
         else:
             raise RuntimeError("Systems other than Linux and Windows are not supported")
 


### PR DESCRIPTION
WinReg path is added after first installation of custom Docset and closing Zeal. Use default for this case

## Describe Your Changes:
If there is no key, use default

### Linked Issues:

## Change Type
### Category
- [ ] This is a Minor Change which does not fit any other category.
- [x] This is a Bugfix
- [ ] This is a Feature Addition
- [ ] This is a CI Change
- [ ] This is a Documentation-Only Change (do not check any of the above boxes if this box is checked)
### Breaking/Non Breaking
- [ ] This is a Breaking Change
- [x] This is a Non-Breaking Change

#### Reasoning

Seems that the value in Registry is created only after first custom doc installation and closing program. In this case we have to use assumed default. User still can change location in UI and this won't impact zeal-cli config, but this is on the user to move data and change config.

## Copyright Assignment
- [x ] I have filled out the copyright assignment at https://copyright.morpheus636.com for this pull request.
- [ ] I **am** Morpheus636 so I do not need to fill out the copyright assignment.

#### Why do I require a copyright assignment?
<details>
<summary> Click to expand </summary>
I require a copyright assignment for changes to my projects for the same reason as the Free Software Foundation, and they do a much better job of explaining it in their post at https://www.gnu.org/licenses/why-assign.en.html than I could ever do.


Please email any questions about the copyright assignment to COPYRIGHT@morpheus636.com
</details>
